### PR TITLE
fix axis twist compensation value being discarded

### DIFF
--- a/klipper/BDsensor.py
+++ b/klipper/BDsensor.py
@@ -315,7 +315,9 @@ class BDPrinterProbe:
             raise self.printer.command_error(reason)
         # Allow axis_twist_compensation to update results
         epos = self.probe_offsets.create_probe_result(ppos)
-        self.printer.send_event("probe:update_results", [epos])
+        poslist = [epos]
+        self.printer.send_event("probe:update_results", poslist)
+        epos = poslist[0]
         # add z compensation to probe position
         gcode = self.printer.lookup_object('gcode')
         gcode.respond_info("probe: at %.3f,%.3f bed will contact at z=%.6f"
@@ -358,7 +360,9 @@ class BDPrinterProbe:
             + self.z_offset
         epos = self.probe_offsets.create_probe_result(ppos)
         # Allow axis_twist_compensation to update results
-        self.printer.send_event("probe:update_results", [epos])
+        poslist = [epos]
+        self.printer.send_event("probe:update_results", poslist)
+        epos = poslist[0]
         # Report results
         gcode = self.printer.lookup_object('gcode')
         gcode.respond_info("0probe: at %.3f,%.3f bed will contact at z=%.6f"
@@ -406,9 +410,11 @@ class BDPrinterProbe:
                     pos[2] = pos[2] - intd + self.mcu_probe.endstop_bdsensor_offset \
                         + self.z_offset
                     epos = self.probe_offsets.create_probe_result(pos)
-                    self.mcu_probe.results.append(epos)
                     # Allow axis_twist_compensation to update results
-                    #self.printer.send_event("probe:update_results", [epos])
+                    poslist = [epos]
+                    self.printer.send_event("probe:update_results", poslist)
+                    epos = poslist[0]
+                    self.mcu_probe.results.append(epos)
                     # limit the message output to the console else it may take a lot of time
                     if len(self.mcu_probe.results) < 500:
                         self.gcode.respond_info("probe: at %.3f,%.3f bed will contact at z=%.6f"
@@ -469,7 +475,9 @@ class BDPrinterProbe:
                         + self.z_offset
                     epos = self.probe_offsets.create_probe_result(pos)
                     # Allow axis_twist_compensation to update results
-                    self.printer.send_event("probe:update_results", [epos])
+                    poslist = [epos]
+                    self.printer.send_event("probe:update_results", poslist)
+                    epos = poslist[0]
                     # Report results
                     gcode = self.printer.lookup_object('gcode')
                     gcode.respond_info("run probe: at %.3f,%.3f bed will contact at z=%.6f"


### PR DESCRIPTION
Scenario A: -1,0,1 z_compensation values

Before:
<img width="1666" height="767" alt="image" src="https://github.com/user-attachments/assets/d2d0e9bc-0200-430b-9274-173ed05a5db1" />

After:
<img width="1662" height="778" alt="image" src="https://github.com/user-attachments/assets/26682881-6564-46ba-a100-a69f7c13c3b8" />

Scenario B: 1,0,-1 z_compensation values

Before:
<img width="1672" height="771" alt="image" src="https://github.com/user-attachments/assets/0cb471b2-6c5a-40a2-bbac-e4e43db02916" />

After:
<img width="1667" height="752" alt="image" src="https://github.com/user-attachments/assets/efee6a30-dd78-42da-9340-576f8689a4d8" />